### PR TITLE
Fix very silly Bug in form alter internal call

### DIFF
--- a/metrodora.module
+++ b/metrodora.module
@@ -407,13 +407,14 @@ function metrodora_compound_child_metadata_access(AbstractObject $object) {
  */
 function metrodora_build_repeatable_element_array(&$form, $field_key = FALSE) {
   $elements = array();
-
-  foreach (element_children($form) as $key) {
-    if ($field_key) {
-      $elements[] = &$form[$key][$field_key];
-    }
-    else {
-      $elements[] = &$form[$key];
+  if (!empty($form)) {
+    foreach (element_children($form) as $key) {
+      if ($field_key) {
+        $elements[] = &$form[$key][$field_key];
+      }
+      else {
+        $elements[] = &$form[$key];
+      }
     }
   }
   return $elements;


### PR DESCRIPTION
This error should have popped long ago. Never ever call element_children without being sure you have something to pass. This failed on 7.x-1.6 and greater so had to fix it.
