### PR TITLE
Enables MODS edit button outside Manage Tab

### DIFF
--- a/metrodora.module
+++ b/metrodora.module
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * Metro specific Islandora functionality.
@@ -299,12 +300,13 @@ function metrodora_menu_alter(&$items) {
 function metrodora_admin_paths() {
   // This little hook allows this menu items to be configured
   // to be openend in an Overlay plus other goodies.
-  // It's more flexible than passing option with 
+  // It's more flexible than passing option with
   // fragment to drupal_goto.
   $paths = array();
   $paths['islandora/object/*/edit_mods-metadata'] = TRUE;
   return $paths;
 }
+
 /**
  * Implements hook_form_alter().
  */
@@ -373,7 +375,7 @@ function metrodora_metadata_tab_access(AbstractObject $object) {
 function metrodora_mods_tab_access(AbstractObject $object) {
   module_load_include('inc', 'metrodora', 'includes/utilities');
   $access = FALSE;
-  // This disables mods tab for collection objects
+  // This disables mods tab for collection objects.
   if (is_object($object) && isset($object['MODS']) && !in_array('islandora:collectionCModel', $object->models)) {
     $access = islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $object['MODS']);
   }
@@ -391,7 +393,7 @@ function metrodora_mods_tab_access(AbstractObject $object) {
  */
 function metrodora_marcxml_tab_access(AbstractObject $object) {
   $access = FALSE;
-  // This disables marcxml for collection objects
+  // This disables marcxml for collection objects.
   if (islandora_marcxml_access_callback($object) && !in_array('islandora:collectionCModel', $object->models)) {
     $access = TRUE;
   }
@@ -410,10 +412,9 @@ function metrodora_marcxml_tab_access(AbstractObject $object) {
 function metrodora_mods_edit_access(AbstractObject $object) {
   module_load_include('inc', 'metrodora', 'includes/utilities');
   $access = FALSE;
-  // This disables mods tab for collection objects
   if (is_object($object) && isset($object['MODS'])) {
     module_load_include('inc', 'islandora', 'includes/utilities');
-    //Mimics same functioality present in the manage tag -> datastreams
+    // Mimics same functionality present in the manage tab -> datastreams.
     $edit_registry = islandora_build_datastream_edit_registry($object['MODS']);
     $access = count($edit_registry) > 0 && islandora_datastream_access(ISLANDORA_METADATA_EDIT, $object['MODS']);
   }
@@ -425,7 +426,6 @@ function metrodora_mods_edit_access(AbstractObject $object) {
  *
  * @param AbstractObject $object
  *   An AbstractObject representing a Fedora object.
- *
  */
 function metrodora_mods_edit_callback(AbstractObject $object) {
   drupal_goto("islandora/object/{$object->id}/datastream/MODS/edit");

--- a/metrodora.module
+++ b/metrodora.module
@@ -260,6 +260,15 @@ function metrodora_menu() {
     'delivery callback' => 'metrodora_mods_download',
     'file' => 'includes/utilities.inc',
   );
+  $items['islandora/object/%islandora_object/edit_mods-metadata'] = array(
+    'title' => 'Edit MODS XML',
+    'type' => MENU_LOCAL_TASK,
+    'page callback' => 'metrodora_mods_edit_callback',
+    'page arguments' => array(2),
+    'access callback' => 'metrodora_mods_edit_access',
+    'access arguments' => array(2),
+    'weight' => 10,
+  );
   return $items;
 }
 
@@ -284,6 +293,18 @@ function metrodora_menu_alter(&$items) {
   }
 }
 
+/**
+ * Implements hook_admin_paths().
+ */
+function metrodora_admin_paths() {
+  // This little hook allows this menu items to be configured
+  // to be openend in an Overlay plus other goodies.
+  // It's more flexible than passing option with 
+  // fragment to drupal_goto.
+  $paths = array();
+  $paths['islandora/object/*/edit_mods-metadata'] = TRUE;
+  return $paths;
+}
 /**
  * Implements hook_form_alter().
  */
@@ -375,6 +396,39 @@ function metrodora_marcxml_tab_access(AbstractObject $object) {
     $access = TRUE;
   }
   return $access;
+}
+
+/**
+ * Access callback wrapper for Editing MODS datastream.
+ *
+ * @param AbstractObject $object
+ *   An AbstractObject representing a Fedora object.
+ *
+ * @return bool
+ *   TRUE if the user can Edit Mods, FALSE otherwise.
+ */
+function metrodora_mods_edit_access(AbstractObject $object) {
+  module_load_include('inc', 'metrodora', 'includes/utilities');
+  $access = FALSE;
+  // This disables mods tab for collection objects
+  if (is_object($object) && isset($object['MODS'])) {
+    module_load_include('inc', 'islandora', 'includes/utilities');
+    //Mimics same functioality present in the manage tag -> datastreams
+    $edit_registry = islandora_build_datastream_edit_registry($object['MODS']);
+    $access = count($edit_registry) > 0 && islandora_datastream_access(ISLANDORA_METADATA_EDIT, $object['MODS']);
+  }
+  return $access;
+}
+
+/**
+ * Page callback wrapper for Editing MODS datastream.
+ *
+ * @param AbstractObject $object
+ *   An AbstractObject representing a Fedora object.
+ *
+ */
+function metrodora_mods_edit_callback(AbstractObject $object) {
+  drupal_goto("islandora/object/{$object->id}/datastream/MODS/edit");
 }
 
 /**


### PR DESCRIPTION
Mimics same behaviour found for "Edit" datastream in Object manage tab. It preserves permission handling and access definition, basically if "Edit" link is accesible for MODS datastream from inside Manage tab -> datastreams then this new Tab will be also.
